### PR TITLE
removed '$' from README so a one line copy eases the usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 Suppose that the input file is "data.gfa".
 
 ```bash
-$ git clone https://github.com/graph-genome/pipeline
-$ cd pipeline
-$ cp /pass/to/your/data.gfa .
-$ docker build -t pipeline .
-$ docker run -ti --rm --publish=3000:3000 --volume=`pwd`:/usr/src/app/data pipeline data/data.gfa
-$ docker run -ti --rm --publish=3000:3000 --volume=`pwd`:/usr/src/app/data pipeline data/data.gfa 10000 
-  # You can change bin width.
+git clone https://github.com/graph-genome/pipeline
+cd pipeline
+cp /pass/to/your/data.gfa .
+docker build -t pipeline .
+docker run -ti --rm --publish=3000:3000 --volume=`pwd`:/usr/src/app/data pipeline data/data.gfa
+docker run -ti --rm --publish=3000:3000 --volume=`pwd`:/usr/src/app/data pipeline data/data.gfa 10000 
+  # With the last argument you can change the bin width.
 ```
 
 Access to http://localhost:3000/.


### PR DESCRIPTION
I can no double click on each line of the example commands.